### PR TITLE
backport-include: fix linux/acpi_amd_wbrf.h inclusion

### DIFF
--- a/backport/backport-include/linux/acpi_amd_wbrf.h
+++ b/backport/backport-include/linux/acpi_amd_wbrf.h
@@ -8,6 +8,7 @@
 #define _ACPI_AMD_WBRF_H
 
 #if LINUX_VERSION_IS_GEQ(6,8,0)
+#undef _ACPI_AMD_WBRF_H
 #include_next <linux/acpi_amd_wbrf.h>
 #else
 #include <linux/device.h>


### PR DESCRIPTION
Fix building for kernel >= 6.8 by adjusting an incorrect guard usage, otherwise an `#include_next` header is masked and compilation will fail for net/mac80211/wbrf.c in the `mac80211` kernel module.

Fixes: 52cdcaab ("backport-include: backport linux/acpi_amd_wbrf.h")

This patch complements my OpenWrt mac80211 PR [#17456](https://github.com/openwrt/openwrt/pull/17456).

CC: @nbd168 @hauke @PolynomialDivision @robimarko 

Happy New Year!